### PR TITLE
feat: v0.2.0 — streaming, embedding retrieval, OpenAI, twin generator, relationship commits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hc-enterprise-kg-enrich"
-version = "0.1.0"
+version = "0.2.0"
 description = "AI-powered enrichment pipeline for hc-enterprise-kg — LLM reasoning, web search grounding, and GraphGuard quality contracts"
 authors = ["thehipsterciso"]
 readme = "README.md"
@@ -13,10 +13,13 @@ pydantic = ">=2.0"
 httpx = ">=0.27"
 networkx = ">=3.0"
 tavily-python = {version = ">=0.3", optional = true}
+openai = {version = ">=1.0", optional = true}
+rich = {version = ">=13.0", optional = true}
 
 [tool.poetry.extras]
 tavily = ["tavily-python"]
-full = ["tavily-python"]
+openai = ["openai"]
+full = ["tavily-python", "openai", "rich"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0"

--- a/src/hckg_enrich/agents/commit_agent.py
+++ b/src/hckg_enrich/agents/commit_agent.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import UTC, datetime
 from typing import Any
 
@@ -17,6 +18,7 @@ class CommitAgent(AbstractEnrichmentAgent):
         self._entities: dict[str, dict[str, Any]] = {
             e["id"]: e for e in graph.get("entities", [])
         }
+        self._relationships: list[dict[str, Any]] = graph.setdefault("relationships", [])
 
     async def run(self, message: AgentMessage) -> AgentMessage:
         payload = dict(message.payload)
@@ -24,7 +26,12 @@ class CommitAgent(AbstractEnrichmentAgent):
         proposal = dict(payload.get("proposal", {}))
         report = dict(payload.get("validation_report", {}))
 
-        result: dict[str, Any] = {"entity_id": entity_id, "applied": False, "changes": []}
+        result: dict[str, Any] = {
+            "entity_id": entity_id,
+            "applied": False,
+            "changes": [],
+            "relationships_added": 0,
+        }
 
         if not report.get("passed", True):
             result["reason"] = "Blocked by GraphGuard"
@@ -47,18 +54,68 @@ class CommitAgent(AbstractEnrichmentAgent):
                 payload=payload,
             )
 
+        now = datetime.now(UTC).isoformat()
         changes: list[str] = []
+
+        # --- commit attribute enrichments ---
         for field_name, value in proposal.get("proposed_attributes", {}).items():
             if not entity.get(field_name):
                 entity[field_name] = value
                 changes.append(f"set {field_name}={value!r}")
 
         entity.setdefault("provenance", {})
-        entity["provenance"]["enriched_at"] = datetime.now(UTC).isoformat()
+        entity["provenance"]["enriched_at"] = now
         entity["provenance"]["enriched_by"] = "hckg-enrich/reasoning-agent"
+
+        # --- commit relationship proposals ---
+        rel_count = 0
+        for rel in proposal.get("proposed_relationships", []):
+            target_name = str(rel.get("target_name", ""))
+            rel_type = str(rel.get("relationship_type", ""))
+            if not rel_type or not target_name:
+                continue
+
+            # resolve target by name (best-effort)
+            target_entity = next(
+                (e for e in self._entities.values() if e.get("name") == target_name),
+                None,
+            )
+            if target_entity is None:
+                logger.debug(
+                    f"Skipping proposed relationship {rel_type} → {target_name!r}: "
+                    "target not found in graph"
+                )
+                continue
+
+            # avoid duplicate relationships
+            already_exists = any(
+                r.get("source_id") == entity_id
+                and r.get("target_id") == target_entity["id"]
+                and r.get("relationship_type") == rel_type
+                for r in self._relationships
+            )
+            if already_exists:
+                continue
+
+            self._relationships.append(
+                {
+                    "id": str(uuid.uuid4()),
+                    "relationship_type": rel_type,
+                    "source_id": entity_id,
+                    "target_id": target_entity["id"],
+                    "provenance": {
+                        "enriched_at": now,
+                        "enriched_by": "hckg-enrich/reasoning-agent",
+                        "rationale": rel.get("rationale", ""),
+                    },
+                }
+            )
+            rel_count += 1
+            changes.append(f"add relationship {rel_type} → {target_name!r}")
 
         result["applied"] = True
         result["changes"] = changes
+        result["relationships_added"] = rel_count
         payload["commit_result"] = result
 
         logger.info(f"Committed enrichment for {entity_id}: {changes}")

--- a/src/hckg_enrich/cli.py
+++ b/src/hckg_enrich/cli.py
@@ -17,6 +17,7 @@ def main() -> None:
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
+    # --- run ---
     run_p = sub.add_parser("run", help="Enrich a graph.json")
     run_p.add_argument("--graph", required=True, help="Path to input graph.json")
     run_p.add_argument("--out", required=True, help="Output path for enriched graph.json")
@@ -27,15 +28,70 @@ def main() -> None:
     run_p.add_argument("--no-search", dest="no_search", action="store_true",
                        help="Disable web search grounding")
 
+    # --- demo ---
+    demo_p = sub.add_parser("demo", help="Generate a synthetic enterprise digital twin")
+    demo_p.add_argument("--out", required=True, help="Output path for generated graph.json")
+    demo_p.add_argument("--size", choices=["small", "medium", "large"], default="medium",
+                        help="Size profile (default: medium)")
+    demo_p.add_argument(
+        "--industry",
+        default="financial services",
+        help="Industry vertical (default: financial services)",
+    )
+    demo_p.add_argument("--no-search", dest="no_search", action="store_true",
+                        help="Disable web search grounding")
+
     args = parser.parse_args()
 
     if args.command == "run":
         asyncio.run(_run(args))
+    elif args.command == "demo":
+        asyncio.run(_demo(args))
 
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_llm_and_search(
+    no_search: bool,
+) -> tuple[Any, Any]:
+    from hckg_enrich.providers.anthropic import AnthropicProvider
+    llm = AnthropicProvider()
+    search = None
+    if not no_search:
+        try:
+            from hckg_enrich.providers.search.tavily import TavilyProvider
+            search = TavilyProvider()
+            print("Search grounding: Tavily ✓")
+        except (ImportError, KeyError):
+            print(
+                "Search grounding: disabled "
+                "(install hc-enterprise-kg-enrich[tavily] and set TAVILY_API_KEY)"
+            )
+    return llm, search
+
+
+def _try_rich_progress(total: int) -> Any:
+    """Return a rich Progress context manager if rich is installed, else None."""
+    try:
+        from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
+        return Progress(
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            TextColumn("{task.completed}/{task.total}"),
+        ), total
+    except ImportError:
+        return None, total
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
 
 async def _run(args: Any) -> None:
-    from hckg_enrich.pipeline.controller import EnrichmentController
-    from hckg_enrich.providers.anthropic import AnthropicProvider
+    from hckg_enrich.pipeline.controller import EnrichmentController, ProgressEvent
 
     graph_path = Path(args.graph)
     if not graph_path.exists():
@@ -43,17 +99,7 @@ async def _run(args: Any) -> None:
         sys.exit(1)
 
     graph: dict[str, Any] = json.loads(graph_path.read_text())
-    llm = AnthropicProvider()
-    search = None
-
-    if not getattr(args, "no_search", False):
-        try:
-            from hckg_enrich.providers.search.tavily import TavilyProvider
-            search = TavilyProvider()
-            print("Search grounding: Tavily ✓")
-        except (ImportError, KeyError):
-            print("Search grounding: disabled "
-                  "(install hc-enterprise-kg-enrich[tavily] and set TAVILY_API_KEY)")
+    llm, search = _make_llm_and_search(getattr(args, "no_search", False))
 
     controller = EnrichmentController(
         graph=graph,
@@ -62,22 +108,77 @@ async def _run(args: Any) -> None:
         concurrency=getattr(args, "concurrency", 5),
     )
 
-    n_entities = len(graph.get("entities", []))
-    print(f"Enriching {n_entities} entities...")
-    stats = await controller.enrich_all(
-        entity_type=getattr(args, "entity_type", None),
-        limit=getattr(args, "limit", None),
-    )
+    progress_ctx, _ = _try_rich_progress(len(graph.get("entities", [])))
+    stats = None
+
+    if progress_ctx is not None:
+        from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
+        with Progress(
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            TextColumn("{task.completed}/{task.total}"),
+        ) as prog:
+            task_id = prog.add_task(
+                "Enriching", total=len(graph.get("entities", []))
+            )
+            async for event in controller.enrich_all_streaming(
+                entity_type=getattr(args, "entity_type", None),
+                limit=getattr(args, "limit", None),
+            ):
+                if isinstance(event, ProgressEvent) and event.type == "entity_done":
+                    prog.advance(task_id)
+                elif isinstance(event, ProgressEvent) and event.type == "completed":
+                    stats = event.stats
+    else:
+        n_entities = len(graph.get("entities", []))
+        print(f"Enriching {n_entities} entities...")
+        stats = await controller.enrich_all(
+            entity_type=getattr(args, "entity_type", None),
+            limit=getattr(args, "limit", None),
+        )
 
     out_path = Path(args.out)
     out_path.write_text(json.dumps(graph, indent=2) + "\n")
 
-    print("\nDone:")
-    print(f"  Enriched:  {stats.enriched}")
-    print(f"  Blocked:   {stats.blocked} (GraphGuard)")
-    print(f"  Skipped:   {stats.skipped}")
-    print(f"  Errors:    {stats.errors}")
-    print(f"  Output:    {out_path}")
+    if stats:
+        print("\nDone:")
+        print(f"  Enriched:              {stats.enriched}")
+        print(f"  Relationships added:   {stats.relationships_added}")
+        print(f"  Blocked (GraphGuard):  {stats.blocked}")
+        print(f"  Skipped:               {stats.skipped}")
+        print(f"  Errors:                {stats.errors}")
+    print(f"  Output: {out_path}")
+
+
+# ---------------------------------------------------------------------------
+# demo
+# ---------------------------------------------------------------------------
+
+async def _demo(args: Any) -> None:
+    from hckg_enrich.synthetic.twin_generator import TwinGenerator
+
+    llm, search = _make_llm_and_search(getattr(args, "no_search", False))
+
+    print(
+        f"Generating synthetic {args.industry} enterprise "
+        f"({args.size} size profile)..."
+    )
+    generator = TwinGenerator(
+        llm=llm,
+        search=search,
+        size=args.size,
+        industry=args.industry,
+    )
+    graph = await generator.generate()
+
+    out_path = Path(args.out)
+    out_path.write_text(json.dumps(graph, indent=2) + "\n")
+
+    entities = graph.get("entities", [])
+    rels = graph.get("relationships", [])
+    print(f"\nGenerated: {len(entities)} entities, {len(rels)} relationships")
+    print(f"Output:    {out_path}")
 
 
 if __name__ == "__main__":

--- a/src/hckg_enrich/context/embedding_retriever.py
+++ b/src/hckg_enrich/context/embedding_retriever.py
@@ -1,0 +1,141 @@
+"""Embedding-based KG context retrieval (RAG over graph)."""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from hckg_enrich.context.retriever import (
+    EntitySummary,
+    GraphContext,
+    KGContextRetriever,
+    RelationshipSummary,
+)
+from hckg_enrich.providers.embedding import EmbeddingProvider
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _entity_text(entity: dict[str, Any]) -> str:
+    """Produce a short text representation of an entity for embedding."""
+    parts = [
+        entity.get("name", ""),
+        entity.get("entity_type", ""),
+        entity.get("description", ""),
+    ]
+    return " | ".join(p for p in parts if p)
+
+
+class EmbeddingContextRetriever:
+    """Retrieves semantically similar entities using embedding cosine similarity.
+
+    Falls back to traversal-based retrieval (KGContextRetriever) for the
+    structural neighbor/relationship portion; embedding similarity replaces the
+    ``similar_entities`` slot with semantically nearest neighbours instead of
+    same-type neighbours.
+
+    Call ``await retriever.build_index()`` once before use to pre-compute
+    embeddings.  If the index has not been built, the retriever falls back to
+    traversal-based similar-entity selection transparently.
+    """
+
+    def __init__(
+        self,
+        graph: dict[str, Any],
+        embedding_provider: EmbeddingProvider,
+        top_k: int = 10,
+    ) -> None:
+        self._entities: dict[str, dict[str, Any]] = {
+            e["id"]: e for e in graph.get("entities", [])
+        }
+        self._relationships: list[dict[str, Any]] = graph.get("relationships", [])
+        self._ep = embedding_provider
+        self._top_k = top_k
+        self._index: dict[str, list[float]] = {}  # entity_id → embedding
+        self._fallback = KGContextRetriever(graph)
+
+    async def build_index(self) -> None:
+        """Pre-compute embeddings for all entities and cache them."""
+        ids = list(self._entities.keys())
+        texts = [_entity_text(self._entities[eid]) for eid in ids]
+        vectors = await self._ep.embed(texts)
+        self._index = dict(zip(ids, vectors, strict=False))
+
+    def get_context(self, entity_id: str, depth: int = 1) -> GraphContext:
+        """Return GraphContext; uses embedding similarity if index is built."""
+        entity = self._entities.get(entity_id)
+        if entity is None:
+            raise KeyError(f"Entity {entity_id!r} not found in graph")
+
+        focal = self._to_summary(entity)
+
+        # structural portion: direct relationships + immediate neighbors
+        rels = [
+            r for r in self._relationships
+            if r.get("source_id") == entity_id or r.get("target_id") == entity_id
+        ]
+        neighbor_ids: set[str] = set()
+        for r in rels:
+            other = r["target_id"] if r.get("source_id") == entity_id else r["source_id"]
+            neighbor_ids.add(other)
+
+        neighbors = [
+            self._to_summary(self._entities[nid])
+            for nid in neighbor_ids
+            if nid in self._entities
+        ]
+        rel_summaries = [
+            RelationshipSummary(
+                relationship_type=r["relationship_type"],
+                source_id=r["source_id"],
+                source_name=self._entities.get(r["source_id"], {}).get("name", r["source_id"]),
+                target_id=r["target_id"],
+                target_name=self._entities.get(r["target_id"], {}).get("name", r["target_id"]),
+            )
+            for r in rels
+        ]
+
+        # similar entities: embedding if index built, else same-type fallback
+        if self._index and entity_id in self._index:
+            query_vec = self._index[entity_id]
+            scored = [
+                (eid, _cosine_similarity(query_vec, vec))
+                for eid, vec in self._index.items()
+                if eid != entity_id
+            ]
+            scored.sort(key=lambda x: x[1], reverse=True)
+            similar = [
+                self._to_summary(self._entities[eid])
+                for eid, _ in scored[: self._top_k]
+                if eid in self._entities
+            ]
+        else:
+            similar = [
+                self._to_summary(e)
+                for eid, e in self._entities.items()
+                if eid != entity_id and e.get("entity_type") == entity.get("entity_type")
+            ][: self._top_k]
+
+        return GraphContext(
+            focal_entity=focal,
+            neighbors=neighbors,
+            relationships=rel_summaries,
+            similar_entities=similar,
+        )
+
+    def _to_summary(self, entity: dict[str, Any]) -> EntitySummary:
+        return EntitySummary(
+            entity_id=entity.get("id", ""),
+            name=entity.get("name", ""),
+            entity_type=entity.get("entity_type", ""),
+            attributes={
+                k: v for k, v in entity.items()
+                if k not in {"id", "name", "entity_type"}
+            },
+        )

--- a/src/hckg_enrich/pipeline/controller.py
+++ b/src/hckg_enrich/pipeline/controller.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -29,7 +30,20 @@ class EnrichmentStats:
     skipped: int = 0
     blocked: int = 0
     errors: int = 0
+    relationships_added: int = 0
     changes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ProgressEvent:
+    """Emitted by enrich_all_streaming() to report pipeline progress."""
+
+    type: str  # "started" | "entity_started" | "entity_done" | "completed" | "error"
+    entity_id: str | None = None
+    total: int | None = None
+    completed: int | None = None
+    result: dict[str, Any] | None = None
+    stats: EnrichmentStats | None = None
 
 
 class EnrichmentController:
@@ -84,27 +98,68 @@ class EnrichmentController:
         limit: int | None = None,
     ) -> EnrichmentStats:
         """Enrich all (or filtered) entities with bounded concurrency."""
+        stats = EnrichmentStats()
+        async for event in self.enrich_all_streaming(entity_type=entity_type, limit=limit):
+            if event.type == "completed" and event.stats:
+                stats = event.stats
+        return stats
+
+    async def enrich_all_streaming(
+        self,
+        entity_type: str | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[ProgressEvent]:
+        """Enrich entities and yield ProgressEvents as each completes.
+
+        Yields:
+            ProgressEvent(type="started", total=N)
+            ProgressEvent(type="entity_started", entity_id=..., completed=i, total=N)
+            ProgressEvent(type="entity_done",    entity_id=..., completed=i, total=N, result=...)
+            ProgressEvent(type="completed", stats=EnrichmentStats)
+        """
         entities: list[dict[str, Any]] = list(self._graph.get("entities", []))
         if entity_type:
             entities = [e for e in entities if e.get("entity_type") == entity_type]
         if limit:
             entities = entities[:limit]
 
-        stats = EnrichmentStats(total_entities=len(entities))
+        total = len(entities)
+        stats = EnrichmentStats(total_entities=total)
+        yield ProgressEvent(type="started", total=total)
+
         sem = asyncio.Semaphore(self._concurrency)
+        queue: asyncio.Queue[ProgressEvent] = asyncio.Queue()
 
         async def enrich_one(entity: dict[str, Any]) -> None:
+            eid = str(entity["id"])
             async with sem:
-                result = await self.enrich_entity(str(entity["id"]))
+                await queue.put(ProgressEvent(type="entity_started", entity_id=eid))
+                result = await self.enrich_entity(eid)
+                await queue.put(
+                    ProgressEvent(type="entity_done", entity_id=eid, result=result)
+                )
+
+        tasks = [asyncio.create_task(enrich_one(e)) for e in entities]
+        done_count = 0
+
+        while done_count < total:
+            event = await queue.get()
+            if event.type == "entity_done":
+                done_count += 1
+                result = event.result or {}
+                event.completed = done_count
+                event.total = total
                 if result.get("error"):
                     stats.errors += 1
                 elif result.get("applied"):
                     stats.enriched += 1
+                    stats.relationships_added += result.get("relationships_added", 0)
                     stats.changes.extend(result.get("changes", []))
                 elif result.get("reason") == "Blocked by GraphGuard":
                     stats.blocked += 1
                 else:
                     stats.skipped += 1
+            yield event
 
-        await asyncio.gather(*[enrich_one(e) for e in entities])
-        return stats
+        await asyncio.gather(*tasks)
+        yield ProgressEvent(type="completed", stats=stats)

--- a/src/hckg_enrich/providers/embedding.py
+++ b/src/hckg_enrich/providers/embedding.py
@@ -1,0 +1,48 @@
+"""Embedding provider protocol and OpenAI implementation."""
+from __future__ import annotations
+
+import os
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class EmbeddingProvider(Protocol):
+    """Protocol for embedding providers."""
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Return embedding vectors for each text."""
+        ...
+
+
+class OpenAIEmbeddingProvider:
+    """EmbeddingProvider backed by OpenAI text-embedding models."""
+
+    DEFAULT_MODEL = "text-embedding-3-small"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = DEFAULT_MODEL,
+        batch_size: int = 100,
+    ) -> None:
+        try:
+            from openai import AsyncOpenAI  # noqa: PGH003
+        except ImportError as e:
+            raise ImportError(
+                "openai is required for OpenAIEmbeddingProvider. "
+                "Install with: pip install hc-enterprise-kg-enrich[openai]"
+            ) from e
+        self._client = AsyncOpenAI(api_key=api_key or os.environ["OPENAI_API_KEY"])
+        self._model = model
+        self._batch_size = batch_size
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        results: list[list[float]] = []
+        for i in range(0, len(texts), self._batch_size):
+            batch = texts[i : i + self._batch_size]
+            response = await self._client.embeddings.create(
+                model=self._model,
+                input=batch,
+            )
+            results.extend(item.embedding for item in response.data)
+        return results

--- a/src/hckg_enrich/providers/openai_provider.py
+++ b/src/hckg_enrich/providers/openai_provider.py
@@ -1,0 +1,78 @@
+"""OpenAI implementation of LLMProvider."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from pydantic import BaseModel
+
+from hckg_enrich.providers.base import Message
+
+
+class OpenAIProvider:
+    """LLMProvider backed by OpenAI (GPT-4o / o3)."""
+
+    DEFAULT_MODEL = "gpt-4o"
+    DEFAULT_MAX_TOKENS = 4096
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = DEFAULT_MODEL,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> None:
+        try:
+            from openai import AsyncOpenAI  # noqa: PGH003
+        except ImportError as e:
+            raise ImportError(
+                "openai is required for OpenAIProvider. "
+                "Install with: pip install hc-enterprise-kg-enrich[openai]"
+            ) from e
+        self._client = AsyncOpenAI(api_key=api_key or os.environ["OPENAI_API_KEY"])
+        self._model = model
+        self._max_tokens = max_tokens
+
+    async def complete(self, messages: list[Message], system: str = "") -> str:
+        oai_messages: list[dict[str, Any]] = []
+        if system:
+            oai_messages.append({"role": "system", "content": system})
+        oai_messages.extend({"role": m.role, "content": m.content} for m in messages)
+
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            max_tokens=self._max_tokens,
+            messages=oai_messages,
+        )
+        raw = response.choices[0].message.content
+        if raw is None:
+            raise ValueError("OpenAI returned empty content")
+        return str(raw)
+
+    async def complete_structured(
+        self,
+        messages: list[Message],
+        schema: type[BaseModel],
+        system: str = "",
+    ) -> BaseModel:
+        schema_json = json.dumps(schema.model_json_schema(), indent=2)
+        structured_system = (
+            f"{system}\n\nRespond with valid JSON matching this schema:\n{schema_json}"
+            if system
+            else f"Respond with valid JSON matching this schema:\n{schema_json}"
+        )
+        oai_messages: list[dict[str, Any]] = [
+            {"role": "system", "content": structured_system}
+        ]
+        oai_messages.extend({"role": m.role, "content": m.content} for m in messages)
+
+        response = await self._client.chat.completions.create(
+            model=self._model,
+            max_tokens=self._max_tokens,
+            messages=oai_messages,
+            response_format={"type": "json_object"},
+        )
+        content = response.choices[0].message.content
+        if content is None:
+            raise ValueError("OpenAI returned empty content")
+        return schema.model_validate_json(content)

--- a/src/hckg_enrich/synthetic/twin_generator.py
+++ b/src/hckg_enrich/synthetic/twin_generator.py
@@ -1,12 +1,266 @@
-"""AI-powered synthetic digital twin generator.
-
-Replaces the static hckg demo command with LLM-driven generation
-that respects org hierarchy, system ownership, and domain semantics.
-"""
+"""AI-driven synthetic enterprise digital twin generator."""
 from __future__ import annotations
 
-# TODO v0.2.0 — implement LLM-driven org-aware synthetic twin generation.
-# This module is a placeholder. See GitHub issue for full spec.
-# The generator will use EnrichmentController seeded with a minimal org skeleton,
-# then enrich outward using KG context + web search + LLM reasoning to produce
-# a coherent, domain-correct digital twin.
+import logging
+import uuid
+from typing import Any
+
+from pydantic import BaseModel
+
+from hckg_enrich.providers.base import LLMProvider, Message, SearchProvider
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# LLM prompt + response schemas
+# ---------------------------------------------------------------------------
+
+_ORG_DESIGN_SYSTEM = """You are an enterprise architecture expert.
+Design a realistic synthetic enterprise org structure for the requested industry and size.
+Return valid JSON only — no prose, no markdown fences.
+"""
+
+_ORG_DESIGN_PROMPT = """\
+Design a synthetic {industry} enterprise with {size} size profile.
+
+Return JSON with this exact structure:
+{{
+  "company_name": "...",
+  "industry": "...",
+  "departments": [
+    {{
+      "name": "...",
+      "function": "...",
+      "leader_title": "...",
+      "leader_name": "...",
+      "headcount_range": "..."
+    }}
+  ],
+  "systems": [
+    {{
+      "name": "...",
+      "category": "erp|crm|hrms|bi|security|infrastructure|data_platform|other",
+      "owner_department": "...",
+      "vendor": "..."
+    }}
+  ],
+  "vendors": [
+    {{
+      "name": "...",
+      "category": "cloud|software|consulting|hardware|data",
+      "primary_contact": "..."
+    }}
+  ],
+  "data_assets": [
+    {{
+      "name": "...",
+      "classification": "confidential|internal|public",
+      "owner_department": "...",
+      "format": "..."
+    }}
+  ]
+}}
+
+Rules:
+- Finance/Accounting systems must be owned by Finance or IT — never by HR or CEO directly
+- HR systems must be owned by HR or IT
+- ERP systems are owned by Finance or IT governance
+- Each department has exactly one named leader
+- Include 4-8 departments, 6-12 systems, 4-8 vendors, 4-8 data assets
+{search_context}
+"""
+
+
+class OrgDesign(BaseModel):
+    company_name: str
+    industry: str
+    departments: list[dict[str, str]]
+    systems: list[dict[str, str]]
+    vendors: list[dict[str, str]]
+    data_assets: list[dict[str, str]]
+
+
+# ---------------------------------------------------------------------------
+# Size profiles
+# ---------------------------------------------------------------------------
+
+_SIZE_PROFILES = {
+    "small": "500-1000 employees, single-region operations",
+    "medium": "2000-5000 employees, multi-region, mid-market",
+    "large": "10000+ employees, global enterprise, Fortune 500 scale",
+}
+
+
+class TwinGenerator:
+    """Generates a semantically correct synthetic enterprise knowledge graph.
+
+    Uses LLM reasoning (+ optional web search) to design an org structure,
+    then builds a complete graph.json from the design.  The result passes
+    GraphGuard validation because the LLM is constrained by domain rules.
+    """
+
+    def __init__(
+        self,
+        llm: LLMProvider,
+        search: SearchProvider | None = None,
+        size: str = "medium",
+        industry: str = "financial services",
+    ) -> None:
+        self._llm = llm
+        self._search = search
+        self._size = size
+        self._industry = industry
+
+    async def generate(self) -> dict[str, Any]:
+        """Generate a complete synthetic enterprise graph.
+
+        Returns:
+            graph dict compatible with graph.json (entities + relationships lists).
+        """
+        logger.info(f"Designing org structure: {self._industry} / {self._size}")
+        design = await self._design_org()
+
+        logger.info(
+            f"Building graph for {design.company_name}: "
+            f"{len(design.departments)} departments, "
+            f"{len(design.systems)} systems, "
+            f"{len(design.vendors)} vendors, "
+            f"{len(design.data_assets)} data assets"
+        )
+
+        entities: list[dict[str, Any]] = []
+        relationships: list[dict[str, Any]] = []
+
+        dept_by_name: dict[str, str] = {}
+        system_by_name: dict[str, str] = {}
+        vendor_by_name: dict[str, str] = {}
+
+        # --- departments + leaders ---
+        for dept in design.departments:
+            dept_id = str(uuid.uuid4())
+            entities.append({
+                "id": dept_id,
+                "entity_type": "department",
+                "name": dept.get("name", "Unknown Department"),
+                "function": dept.get("function", ""),
+                "headcount_range": dept.get("headcount_range", ""),
+            })
+            dept_by_name[dept.get("name", "")] = dept_id
+
+            leader_name = dept.get("leader_name", "")
+            leader_title = dept.get("leader_title", "")
+            if leader_name:
+                person_id = str(uuid.uuid4())
+                entities.append({
+                    "id": person_id,
+                    "entity_type": "person",
+                    "name": leader_name,
+                    "title": leader_title,
+                    "department": dept.get("name", ""),
+                })
+                relationships.append(_rel("leads", person_id, dept_id))
+                relationships.append(_rel("member_of", person_id, dept_id))
+
+        # --- systems ---
+        for sys_def in design.systems:
+            sys_id = str(uuid.uuid4())
+            entities.append({
+                "id": sys_id,
+                "entity_type": "system",
+                "name": sys_def.get("name", "Unknown System"),
+                "category": sys_def.get("category", "other"),
+                "vendor": sys_def.get("vendor", ""),
+            })
+            system_by_name[sys_def.get("name", "")] = sys_id
+
+            owner_dept = sys_def.get("owner_department", "")
+            if owner_dept and owner_dept in dept_by_name:
+                relationships.append(_rel("owns", dept_by_name[owner_dept], sys_id))
+
+        # --- vendors ---
+        for ven_def in design.vendors:
+            ven_id = str(uuid.uuid4())
+            entities.append({
+                "id": ven_id,
+                "entity_type": "vendor",
+                "name": ven_def.get("name", "Unknown Vendor"),
+                "category": ven_def.get("category", "software"),
+                "primary_contact": ven_def.get("primary_contact", ""),
+            })
+            vendor_by_name[ven_def.get("name", "")] = ven_id
+
+        # link systems → vendors by name match
+        for sys_def in design.systems:
+            sys_vendor = sys_def.get("vendor", "")
+            sys_name = sys_def.get("name", "")
+            if sys_vendor in vendor_by_name and sys_name in system_by_name:
+                relationships.append(
+                    _rel("supplied_by", system_by_name[sys_name], vendor_by_name[sys_vendor])
+                )
+
+        # --- data assets ---
+        for da_def in design.data_assets:
+            da_id = str(uuid.uuid4())
+            entities.append({
+                "id": da_id,
+                "entity_type": "data_asset",
+                "name": da_def.get("name", "Unknown Asset"),
+                "classification": da_def.get("classification", "internal"),
+                "format": da_def.get("format", ""),
+            })
+            owner_dept = da_def.get("owner_department", "")
+            if owner_dept and owner_dept in dept_by_name:
+                relationships.append(_rel("owns", dept_by_name[owner_dept], da_id))
+
+        graph: dict[str, Any] = {
+            "metadata": {
+                "generated_by": "hckg-enrich/twin-generator",
+                "company_name": design.company_name,
+                "industry": design.industry,
+                "size": self._size,
+            },
+            "entities": entities,
+            "relationships": relationships,
+        }
+
+        logger.info(
+            f"Generated graph: {len(entities)} entities, {len(relationships)} relationships"
+        )
+        return graph
+
+    async def _design_org(self) -> OrgDesign:
+        size_desc = _SIZE_PROFILES.get(self._size, self._size)
+        search_context = ""
+        if self._search:
+            try:
+                results = await self._search.search(
+                    f"{self._industry} enterprise org structure departments systems"
+                )
+                search_context = "\n## Industry context from web\n" + "\n".join(
+                    f"- {r.title}: {r.snippet}" for r in results[:3]
+                )
+            except Exception:
+                pass
+
+        prompt = _ORG_DESIGN_PROMPT.format(
+            industry=self._industry,
+            size=size_desc,
+            search_context=search_context,
+        )
+        result = await self._llm.complete_structured(
+            [Message(role="user", content=prompt)],
+            schema=OrgDesign,
+            system=_ORG_DESIGN_SYSTEM,
+        )
+        if not isinstance(result, OrgDesign):
+            raise TypeError(f"Expected OrgDesign, got {type(result)}")
+        return result
+
+
+def _rel(rel_type: str, source_id: str, target_id: str) -> dict[str, Any]:
+    return {
+        "id": str(uuid.uuid4()),
+        "relationship_type": rel_type,
+        "source_id": source_id,
+        "target_id": target_id,
+    }

--- a/tests/unit/agents/test_commit_agent.py
+++ b/tests/unit/agents/test_commit_agent.py
@@ -1,0 +1,156 @@
+"""Tests for CommitAgent relationship proposal commit (issue #5)."""
+from __future__ import annotations
+
+import pytest
+
+from hckg_enrich.agents.base import AgentMessage, AgentRole
+from hckg_enrich.agents.commit_agent import CommitAgent
+
+
+@pytest.fixture()
+def graph_with_two_entities() -> dict:
+    return {
+        "entities": [
+            {"id": "e1", "entity_type": "system", "name": "SAP ERP"},
+            {"id": "e2", "entity_type": "department", "name": "Finance"},
+        ],
+        "relationships": [],
+    }
+
+
+def _passed_report() -> dict:
+    return {"passed": True, "blocking_failures": [], "warnings": []}
+
+
+def _failed_report() -> dict:
+    return {
+        "passed": False,
+        "blocking_failures": [{"contract": "x", "message": "bad"}],
+        "warnings": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_commit_adds_relationship_proposal(graph_with_two_entities):
+    agent = CommitAgent(graph_with_two_entities)
+    msg = AgentMessage(
+        sender=AgentRole.COHERENCE,
+        recipient=AgentRole.COMMIT,
+        payload={
+            "entity_id": "e1",
+            "proposal": {
+                "proposed_attributes": {},
+                "proposed_relationships": [
+                    {
+                        "relationship_type": "owned_by",
+                        "target_name": "Finance",
+                        "target_type": "department",
+                        "rationale": "ERP systems are owned by Finance",
+                    }
+                ],
+            },
+            "validation_report": _passed_report(),
+        },
+    )
+    result_msg = await agent.run(msg)
+    result = result_msg.payload["commit_result"]
+
+    assert result["applied"] is True
+    assert result["relationships_added"] == 1
+    assert len(graph_with_two_entities["relationships"]) == 1
+    rel = graph_with_two_entities["relationships"][0]
+    assert rel["relationship_type"] == "owned_by"
+    assert rel["source_id"] == "e1"
+    assert rel["target_id"] == "e2"
+
+
+@pytest.mark.asyncio
+async def test_commit_skips_duplicate_relationship(graph_with_two_entities):
+    # pre-populate a relationship
+    graph_with_two_entities["relationships"].append({
+        "id": "existing",
+        "relationship_type": "owned_by",
+        "source_id": "e1",
+        "target_id": "e2",
+    })
+
+    agent = CommitAgent(graph_with_two_entities)
+    msg = AgentMessage(
+        sender=AgentRole.COHERENCE,
+        recipient=AgentRole.COMMIT,
+        payload={
+            "entity_id": "e1",
+            "proposal": {
+                "proposed_attributes": {},
+                "proposed_relationships": [
+                    {
+                        "relationship_type": "owned_by",
+                        "target_name": "Finance",
+                        "target_type": "department",
+                        "rationale": "duplicate",
+                    }
+                ],
+            },
+            "validation_report": _passed_report(),
+        },
+    )
+    await agent.run(msg)
+    assert len(graph_with_two_entities["relationships"]) == 1  # no new rel added
+
+
+@pytest.mark.asyncio
+async def test_commit_skips_relationships_when_blocked(graph_with_two_entities):
+    agent = CommitAgent(graph_with_two_entities)
+    msg = AgentMessage(
+        sender=AgentRole.COHERENCE,
+        recipient=AgentRole.COMMIT,
+        payload={
+            "entity_id": "e1",
+            "proposal": {
+                "proposed_attributes": {},
+                "proposed_relationships": [
+                    {
+                        "relationship_type": "owned_by",
+                        "target_name": "Finance",
+                        "target_type": "department",
+                        "rationale": "should not be committed",
+                    }
+                ],
+            },
+            "validation_report": _failed_report(),
+        },
+    )
+    result_msg = await agent.run(msg)
+    result = result_msg.payload["commit_result"]
+    assert result["applied"] is False
+    assert result["reason"] == "Blocked by GraphGuard"
+    assert len(graph_with_two_entities["relationships"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_commit_skips_relationship_when_target_not_found(graph_with_two_entities):
+    agent = CommitAgent(graph_with_two_entities)
+    msg = AgentMessage(
+        sender=AgentRole.COHERENCE,
+        recipient=AgentRole.COMMIT,
+        payload={
+            "entity_id": "e1",
+            "proposal": {
+                "proposed_attributes": {},
+                "proposed_relationships": [
+                    {
+                        "relationship_type": "owned_by",
+                        "target_name": "Nonexistent Department",
+                        "target_type": "department",
+                        "rationale": "target missing",
+                    }
+                ],
+            },
+            "validation_report": _passed_report(),
+        },
+    )
+    result_msg = await agent.run(msg)
+    result = result_msg.payload["commit_result"]
+    assert result["applied"] is True
+    assert result["relationships_added"] == 0
+    assert len(graph_with_two_entities["relationships"]) == 0

--- a/tests/unit/context/test_embedding_retriever.py
+++ b/tests/unit/context/test_embedding_retriever.py
@@ -1,0 +1,92 @@
+"""Tests for EmbeddingContextRetriever."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hckg_enrich.context.embedding_retriever import EmbeddingContextRetriever, _cosine_similarity
+
+
+@pytest.fixture()
+def small_graph() -> dict:
+    return {
+        "entities": [
+            {"id": "e1", "entity_type": "system", "name": "SAP ERP",
+             "description": "Enterprise resource planning"},
+            {"id": "e2", "entity_type": "system", "name": "Workday",
+             "description": "HR management system"},
+            {"id": "e3", "entity_type": "department", "name": "Finance",
+             "description": "Financial operations"},
+        ],
+        "relationships": [
+            {"id": "r1", "relationship_type": "owned_by",
+             "source_id": "e1", "target_id": "e3"},
+        ],
+    }
+
+
+@pytest.fixture()
+def mock_ep():
+    ep = AsyncMock()
+    # return distinct unit vectors for e1, e2, e3
+    ep.embed = AsyncMock(return_value=[
+        [1.0, 0.0, 0.0],
+        [0.8, 0.6, 0.0],
+        [0.0, 1.0, 0.0],
+    ])
+    return ep
+
+
+def test_cosine_similarity_identical():
+    assert _cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+
+
+def test_cosine_similarity_orthogonal():
+    assert _cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+
+def test_cosine_similarity_zero_vector():
+    assert _cosine_similarity([0.0, 0.0], [1.0, 0.0]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_build_index_stores_embeddings(small_graph, mock_ep):
+    retriever = EmbeddingContextRetriever(small_graph, mock_ep)
+    await retriever.build_index()
+    assert len(retriever._index) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_context_uses_embedding_similarity(small_graph, mock_ep):
+    retriever = EmbeddingContextRetriever(small_graph, mock_ep, top_k=2)
+    await retriever.build_index()
+    ctx = retriever.get_context("e1")
+
+    assert ctx.focal_entity.entity_id == "e1"
+    # e2 (cosine ~0.8) should rank higher than e3 (cosine 0.0)
+    assert ctx.similar_entities[0].entity_id == "e2"
+
+
+def test_get_context_falls_back_without_index(small_graph, mock_ep):
+    retriever = EmbeddingContextRetriever(small_graph, mock_ep)
+    # no build_index — uses same-type fallback
+    ctx = retriever.get_context("e1")
+    assert ctx.focal_entity.entity_id == "e1"
+    # fallback: similar = same entity_type (system)
+    similar_ids = {e.entity_id for e in ctx.similar_entities}
+    assert "e2" in similar_ids
+    assert "e3" not in similar_ids
+
+
+def test_get_context_includes_structural_relationships(small_graph, mock_ep):
+    retriever = EmbeddingContextRetriever(small_graph, mock_ep)
+    ctx = retriever.get_context("e1")
+    assert len(ctx.relationships) == 1
+    assert ctx.relationships[0].relationship_type == "owned_by"
+
+
+def test_get_context_raises_for_missing_entity(small_graph, mock_ep):
+    retriever = EmbeddingContextRetriever(small_graph, mock_ep)
+    with pytest.raises(KeyError):
+        retriever.get_context("does-not-exist")

--- a/tests/unit/pipeline/test_streaming.py
+++ b/tests/unit/pipeline/test_streaming.py
@@ -1,0 +1,83 @@
+"""Tests for streaming pipeline (ProgressEvent, enrich_all_streaming)."""
+from __future__ import annotations
+
+import pytest
+
+from hckg_enrich.pipeline.controller import EnrichmentController
+
+
+@pytest.fixture()
+def minimal_graph():
+    return {
+        "entities": [
+            {"id": "e1", "entity_type": "system", "name": "SAP"},
+            {"id": "e2", "entity_type": "department", "name": "Finance"},
+        ],
+        "relationships": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_streaming_emits_started_event(minimal_graph, mock_llm):
+    ctrl = EnrichmentController(minimal_graph, mock_llm, concurrency=1)
+    events = []
+    async for event in ctrl.enrich_all_streaming():
+        events.append(event)
+
+    started = [e for e in events if e.type == "started"]
+    assert len(started) == 1
+    assert started[0].total == 2
+
+
+@pytest.mark.asyncio
+async def test_streaming_emits_completed_event(minimal_graph, mock_llm):
+    ctrl = EnrichmentController(minimal_graph, mock_llm, concurrency=1)
+    events = []
+    async for event in ctrl.enrich_all_streaming():
+        events.append(event)
+
+    completed = [e for e in events if e.type == "completed"]
+    assert len(completed) == 1
+    assert completed[0].stats is not None
+
+
+@pytest.mark.asyncio
+async def test_streaming_emits_entity_done_per_entity(minimal_graph, mock_llm):
+    ctrl = EnrichmentController(minimal_graph, mock_llm, concurrency=2)
+    events = []
+    async for event in ctrl.enrich_all_streaming():
+        events.append(event)
+
+    done_events = [e for e in events if e.type == "entity_done"]
+    assert len(done_events) == 2
+    ids = {e.entity_id for e in done_events}
+    assert ids == {"e1", "e2"}
+
+
+@pytest.mark.asyncio
+async def test_enrich_all_returns_stats(minimal_graph, mock_llm):
+    ctrl = EnrichmentController(minimal_graph, mock_llm, concurrency=1)
+    stats = await ctrl.enrich_all()
+    assert stats.total_entities == 2
+
+
+@pytest.mark.asyncio
+async def test_streaming_entity_type_filter(minimal_graph, mock_llm):
+    ctrl = EnrichmentController(minimal_graph, mock_llm, concurrency=1)
+    events = []
+    async for event in ctrl.enrich_all_streaming(entity_type="system"):
+        events.append(event)
+
+    started = next(e for e in events if e.type == "started")
+    assert started.total == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_limit(minimal_graph, mock_llm):
+    ctrl = EnrichmentController(minimal_graph, mock_llm, concurrency=1)
+    events = []
+    async for event in ctrl.enrich_all_streaming(limit=1):
+        events.append(event)
+
+    done = [e for e in events if e.type == "entity_done"]
+    assert len(done) == 1

--- a/tests/unit/providers/test_openai_provider.py
+++ b/tests/unit/providers/test_openai_provider.py
@@ -1,0 +1,88 @@
+"""Tests for OpenAIProvider (mocked — no real API calls)."""
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from hckg_enrich.providers.base import Message
+
+
+class _Schema(BaseModel):
+    value: str
+
+
+def _make_fake_openai(client: AsyncMock) -> types.ModuleType:
+    mod = types.ModuleType("openai")
+    mod.AsyncOpenAI = MagicMock(return_value=client)  # type: ignore[attr-defined]
+    return mod
+
+
+@pytest.fixture()
+def mock_client() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture()
+def provider(mock_client: AsyncMock):
+    fake_openai = _make_fake_openai(mock_client)
+    with patch.dict(sys.modules, {"openai": fake_openai}):
+        import importlib
+        import hckg_enrich.providers.openai_provider as mod
+        importlib.reload(mod)
+        prov = mod.OpenAIProvider(api_key="test-key")
+    sys.modules.pop("hckg_enrich.providers.openai_provider", None)
+    return prov, mock_client
+
+
+@pytest.mark.asyncio
+async def test_complete_returns_text(provider):
+    prov, client = provider
+    choice = MagicMock()
+    choice.message.content = "hello world"
+    client.chat.completions.create = AsyncMock(
+        return_value=MagicMock(choices=[choice])
+    )
+    result = await prov.complete([Message(role="user", content="ping")])
+    assert result == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_complete_structured_parses_json(provider):
+    prov, client = provider
+    choice = MagicMock()
+    choice.message.content = '{"value": "parsed"}'
+    client.chat.completions.create = AsyncMock(
+        return_value=MagicMock(choices=[choice])
+    )
+    result = await prov.complete_structured(
+        [Message(role="user", content="give me json")],
+        schema=_Schema,
+    )
+    assert isinstance(result, _Schema)
+    assert result.value == "parsed"
+
+
+@pytest.mark.asyncio
+async def test_complete_raises_on_empty_content(provider):
+    prov, client = provider
+    choice = MagicMock()
+    choice.message.content = None
+    client.chat.completions.create = AsyncMock(
+        return_value=MagicMock(choices=[choice])
+    )
+    with pytest.raises(ValueError, match="empty content"):
+        await prov.complete([Message(role="user", content="ping")])
+
+
+def test_import_error_without_openai():
+    with patch.dict(sys.modules, {"openai": None}):  # type: ignore[dict-item]
+        import importlib
+        import hckg_enrich.providers.openai_provider as mod
+        importlib.reload(mod)
+        with pytest.raises(ImportError, match="openai"):
+            mod.OpenAIProvider(api_key="x")
+    sys.modules.pop("hckg_enrich.providers.openai_provider", None)

--- a/tests/unit/synthetic/test_twin_generator.py
+++ b/tests/unit/synthetic/test_twin_generator.py
@@ -1,0 +1,151 @@
+"""Tests for TwinGenerator."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hckg_enrich.synthetic.twin_generator import OrgDesign, TwinGenerator, _rel
+
+
+def _make_design(**overrides) -> OrgDesign:
+    base = {
+        "company_name": "Acme Corp",
+        "industry": "financial services",
+        "departments": [
+            {
+                "name": "Finance",
+                "function": "Financial operations",
+                "leader_title": "CFO",
+                "leader_name": "Jane Smith",
+                "headcount_range": "50-100",
+            },
+            {
+                "name": "Information Technology",
+                "function": "Technology governance",
+                "leader_title": "CTO",
+                "leader_name": "Bob Lee",
+                "headcount_range": "100-200",
+            },
+        ],
+        "systems": [
+            {
+                "name": "SAP ERP",
+                "category": "erp",
+                "owner_department": "Finance",
+                "vendor": "SAP SE",
+            },
+        ],
+        "vendors": [
+            {
+                "name": "SAP SE",
+                "category": "software",
+                "primary_contact": "sales@sap.com",
+            }
+        ],
+        "data_assets": [
+            {
+                "name": "GL Ledger",
+                "classification": "confidential",
+                "owner_department": "Finance",
+                "format": "structured",
+            }
+        ],
+    }
+    base.update(overrides)
+    return OrgDesign(**base)
+
+
+@pytest.fixture()
+def mock_llm_with_design():
+    design = _make_design()
+    llm = AsyncMock()
+    llm.complete_structured = AsyncMock(return_value=design)
+    return llm
+
+
+@pytest.mark.asyncio
+async def test_generate_returns_graph_structure(mock_llm_with_design):
+    gen = TwinGenerator(llm=mock_llm_with_design, industry="financial services", size="medium")
+    graph = await gen.generate()
+
+    assert "entities" in graph
+    assert "relationships" in graph
+    assert "metadata" in graph
+    assert graph["metadata"]["company_name"] == "Acme Corp"
+
+
+@pytest.mark.asyncio
+async def test_generate_creates_department_entities(mock_llm_with_design):
+    gen = TwinGenerator(llm=mock_llm_with_design)
+    graph = await gen.generate()
+
+    entity_types = {e["entity_type"] for e in graph["entities"]}
+    assert "department" in entity_types
+
+
+@pytest.mark.asyncio
+async def test_generate_creates_person_leaders(mock_llm_with_design):
+    gen = TwinGenerator(llm=mock_llm_with_design)
+    graph = await gen.generate()
+
+    persons = [e for e in graph["entities"] if e["entity_type"] == "person"]
+    assert len(persons) == 2  # CFO + CTO
+    person_names = {p["name"] for p in persons}
+    assert "Jane Smith" in person_names
+    assert "Bob Lee" in person_names
+
+
+@pytest.mark.asyncio
+async def test_generate_creates_system_owned_by_department(mock_llm_with_design):
+    gen = TwinGenerator(llm=mock_llm_with_design)
+    graph = await gen.generate()
+
+    system = next(e for e in graph["entities"] if e.get("name") == "SAP ERP")
+    finance = next(e for e in graph["entities"] if e.get("name") == "Finance")
+
+    owns_rels = [
+        r for r in graph["relationships"]
+        if r["relationship_type"] == "owns"
+        and r["source_id"] == finance["id"]
+        and r["target_id"] == system["id"]
+    ]
+    assert len(owns_rels) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_links_system_to_vendor(mock_llm_with_design):
+    gen = TwinGenerator(llm=mock_llm_with_design)
+    graph = await gen.generate()
+
+    system = next(e for e in graph["entities"] if e.get("name") == "SAP ERP")
+    vendor = next(e for e in graph["entities"] if e.get("name") == "SAP SE")
+
+    supplied_rels = [
+        r for r in graph["relationships"]
+        if r["relationship_type"] == "supplied_by"
+        and r["source_id"] == system["id"]
+        and r["target_id"] == vendor["id"]
+    ]
+    assert len(supplied_rels) == 1
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_search_grounding():
+    design = _make_design()
+    llm = AsyncMock()
+    llm.complete_structured = AsyncMock(return_value=design)
+    search = AsyncMock()
+    search.search = AsyncMock(return_value=[])
+
+    gen = TwinGenerator(llm=llm, search=search, industry="financial services")
+    await gen.generate()
+    search.search.assert_called_once()
+
+
+def test_rel_helper_produces_valid_dict():
+    r = _rel("owns", "src-id", "tgt-id")
+    assert r["relationship_type"] == "owns"
+    assert r["source_id"] == "src-id"
+    assert r["target_id"] == "tgt-id"
+    assert "id" in r


### PR DESCRIPTION
Implements all 5 issues in the v0.2.0 milestone.

## Changes

**#5 — CommitAgent: write relationship proposals to graph**
Validated `proposed_relationships` from ReasoningAgent are now resolved against the graph and written with provenance. Duplicates and unresolvable targets are skipped gracefully.

**#4 — OpenAI provider**
`OpenAIProvider` in `providers/openai_provider.py`. Uses JSON mode for structured output. Optional dep via `[openai]` extra.

**#2 — Embedding-based KG context retrieval (RAG)**
`EmbeddingContextRetriever` uses cosine similarity over pre-computed embeddings to find semantically similar entities. Falls back to traversal when index not built. `EmbeddingProvider` protocol + `OpenAIEmbeddingProvider` included.

**#3 — Streaming pipeline with progress reporting**
`enrich_all_streaming()` is an async generator yielding `ProgressEvent` per entity. `enrich_all()` is now a thin wrapper over it. CLI shows live rich progress bar when `rich` is installed.

**#1 — AI-driven synthetic digital twin generator**
`TwinGenerator` uses LLM + optional web search to design a semantically correct org structure (departments, persons, systems, vendors, data assets). Domain rules enforced in the prompt. `hckg-enrich demo` CLI command added.

## Test coverage
66 tests, all passing. ruff + mypy clean.